### PR TITLE
Add polygon offset to renderer

### DIFF
--- a/src/main/java/software/bernie/geckolib3/renderers/geo/IGeoRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/IGeoRenderer.java
@@ -40,6 +40,8 @@ public interface IGeoRenderer<T> {
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GlStateManager.enableBlend();
         GL11.glEnable(GL11.GL_TEXTURE_2D);
+        GlStateManager.enablePolygonOffset();
+        GlStateManager.doPolygonOffset(1f, 1f);
         renderEarly(model, animatable, partialTicks, red, green, blue, alpha);
 
         renderLate(model, animatable, partialTicks, red, green, blue, alpha);
@@ -54,6 +56,8 @@ public interface IGeoRenderer<T> {
         }
 
         Tessellator.instance.draw();
+
+        GlStateManager.disablePolygonOffset();
 
         renderAfter(model, animatable, partialTicks, red, green, blue, alpha);
         //GlStateManager.disableRescaleNormal();


### PR DESCRIPTION
## Summary
- avoid z-fighting by enabling polygon offset in `IGeoRenderer.render`

## Testing
- `./gradlew build -x test` *(fails: Plugin [id: 'com.gtnewhorizons.retrofuturagradle', version: '1.3.24'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881d3553ef88323a1524b6f435b833e