### PR TITLE
Fix z-fighting with flat cubes

### DIFF
--- a/src/main/java/software/bernie/geckolib3/geo/render/built/GeoCube.java
+++ b/src/main/java/software/bernie/geckolib3/geo/render/built/GeoCube.java
@@ -37,6 +37,10 @@ public class GeoCube implements Serializable {
         cube.mirror = cubeIn.getMirror();
         cube.inflate = cubeIn.getInflate() == null ? (boneInflate == null ? 0 : boneInflate) : cubeIn.getInflate() / 16;
 
+        if (cube.inflate == 0 && (cube.size.x == 0 || cube.size.y == 0 || cube.size.z == 0)) {
+            cube.inflate = 0.001;
+        }
+
         float textureHeight = properties.getTextureHeight().floatValue();
         float textureWidth = properties.getTextureWidth().floatValue();
 

--- a/src/main/java/software/bernie/geckolib3/renderers/geo/IGeoRenderer.java
+++ b/src/main/java/software/bernie/geckolib3/renderers/geo/IGeoRenderer.java
@@ -115,6 +115,12 @@ public interface IGeoRenderer<T> {
         MATRIX_STACK.rotate(cube);
         MATRIX_STACK.moveBackFromPivot(cube);
 
+        boolean flat = cube.size.x == 0 || cube.size.y == 0 || cube.size.z == 0;
+        if (flat) {
+            GlStateManager.enablePolygonOffset();
+            GlStateManager.doPolygonOffset(-1.0F, -10.0F);
+        }
+
         for (GeoQuad quad : cube.quads) {
             if (quad == null) continue;
             Vector3f normal = new Vector3f(quad.normal.getX(), quad.normal.getY(), quad.normal.getZ());
@@ -143,6 +149,11 @@ public interface IGeoRenderer<T> {
                 builder.setNormal(normal.x, normal.y, normal.z);
                 builder.addVertexWithUV(vector4f.x, vector4f.y, vector4f.z, vertex.textureU, vertex.textureV);
             }
+        }
+
+        if (flat) {
+            GlStateManager.disablePolygonOffset();
+            GlStateManager.doPolygonOffset(0.0F, 0.0F);
         }
     }
 


### PR DESCRIPTION
## Summary
- expand flat cubes slightly by default when no inflate value is specified

## Testing
- `./gradlew test --no-daemon` *(fails: could not resolve `com.gtnewhorizons.retrofuturagradle` plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6882b9e3b62483239653bdb7dc99c820